### PR TITLE
Use floating point precision for statsd timings

### DIFF
--- a/statsd_sink.go
+++ b/statsd_sink.go
@@ -2,8 +2,8 @@ package health
 
 import (
 	"bytes"
+	"fmt"
 	"net"
-	"strconv"
 	"time"
 )
 
@@ -114,7 +114,7 @@ func (s *StatsDSink) measure(key string, nanos int64) {
 	var msg bytes.Buffer
 	msg.WriteString(key)
 	msg.WriteRune(':')
-	msg.WriteString(strconv.FormatInt(nanos/1000000, 10))
+	msg.WriteString(fmt.Sprintf("%f", float64(nanos)/float64(time.Millisecond)))
 	msg.WriteString("|ms\n")
 	s.send(msg.Bytes())
 }

--- a/statsd_sink_test.go
+++ b/statsd_sink_test.go
@@ -89,7 +89,7 @@ func TestStatsDSinkEmitEventErrNoPrefix(t *testing.T) {
 func TestStatsDSinkEmitTimingPrefix(t *testing.T) {
 	sink, err := NewStatsDSink(testAddr, "metroid")
 	assert.NoError(t, err)
-	listenFor(t, []string{"metroid.my.event:123|ms\n", "metroid.my.job.my.event:123|ms\n"}, func() {
+	listenFor(t, []string{"metroid.my.event:123.456789|ms\n", "metroid.my.job.my.event:123.456789|ms\n"}, func() {
 		sink.EmitTiming("my.job", "my.event", 123456789, nil)
 	})
 }
@@ -97,7 +97,7 @@ func TestStatsDSinkEmitTimingPrefix(t *testing.T) {
 func TestStatsDSinkEmitTimingNoPrefix(t *testing.T) {
 	sink, err := NewStatsDSink(testAddr, "")
 	assert.NoError(t, err)
-	listenFor(t, []string{"my.event:123|ms\n", "my.job.my.event:123|ms\n"}, func() {
+	listenFor(t, []string{"my.event:123.456789|ms\n", "my.job.my.event:123.456789|ms\n"}, func() {
 		sink.EmitTiming("my.job", "my.event", 123456789, nil)
 	})
 }
@@ -106,7 +106,7 @@ func TestStatsDSinkEmitCompletePrefix(t *testing.T) {
 	sink, err := NewStatsDSink(testAddr, "metroid")
 	assert.NoError(t, err)
 	for kind, kindStr := range completionStatusToString {
-		str := fmt.Sprintf("metroid.my.job.%s:129|ms\n", kindStr)
+		str := fmt.Sprintf("metroid.my.job.%s:129.456789|ms\n", kindStr)
 		listenFor(t, []string{str}, func() {
 			sink.EmitComplete("my.job", kind, 129456789, nil)
 		})
@@ -117,9 +117,17 @@ func TestStatsDSinkEmitCompleteNoPrefix(t *testing.T) {
 	sink, err := NewStatsDSink(testAddr, "")
 	assert.NoError(t, err)
 	for kind, kindStr := range completionStatusToString {
-		str := fmt.Sprintf("my.job.%s:129|ms\n", kindStr)
+		str := fmt.Sprintf("my.job.%s:129.456789|ms\n", kindStr)
 		listenFor(t, []string{str}, func() {
 			sink.EmitComplete("my.job", kind, 129456789, nil)
 		})
 	}
+}
+
+func TestStatsDSinkEmitTimingSubMillisecond(t *testing.T) {
+	sink, err := NewStatsDSink(testAddr, "metroid")
+	assert.NoError(t, err)
+	listenFor(t, []string{"metroid.my.event:0.456789|ms\n", "metroid.my.job.my.event:0.456789|ms\n"}, func() {
+		sink.EmitTiming("my.job", "my.event", 456789, nil)
+	})
 }


### PR DESCRIPTION
otherwise sub-millisecond timings will be truncated to 0 when cast
to an integer type.

The StatsD spec supports float values:
[The protocol allows for both integer and floating point values.](https://github.com/b/statsd_spec#metric-types--formats)