### PR TITLE
Implement Stringer on CompletionStatus

### DIFF
--- a/health.go
+++ b/health.go
@@ -48,6 +48,10 @@ var completionStatusToString = map[CompletionStatus]string{
 	Junk:            "junk",
 }
 
+func (cs CompletionStatus) String() string {
+	return completionStatusToString[cs]
+}
+
 type Sink interface {
 	EmitEvent(job string, event string, kvs map[string]string)
 	EmitEventErr(job string, event string, err error, kvs map[string]string)

--- a/statsd_sink.go
+++ b/statsd_sink.go
@@ -72,7 +72,7 @@ func (s *StatsDSink) EmitComplete(job string, status CompletionStatus, nanos int
 	}
 	b.WriteString(s.SanitizationFunc(job))
 	b.WriteRune('.')
-	b.WriteString(completionStatusToString[status])
+	b.WriteString(status.String())
 
 	s.measure(b.String(), nanos)
 }

--- a/writer_sink.go
+++ b/writer_sink.go
@@ -71,7 +71,7 @@ func (s *WriterSink) EmitComplete(job string, status CompletionStatus, nanos int
 	b.WriteString("]: job:")
 	b.WriteString(job)
 	b.WriteString(" status:")
-	b.WriteString(completionStatusToString[status])
+	b.WriteString(status.String())
 	b.WriteString(" time:")
 	writeNanoseconds(&b, nanos)
 	writeMapConsistently(&b, kvs)


### PR DESCRIPTION
this lets sinks defined outside the health package use the canonical
name for a CompletionStatus in their output.