### PR TITLE
fix goroutine shutdown

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -27,10 +27,11 @@ func startAggregator(intervalDuration time.Duration, retain time.Duration, sink 
 
 	agg := newAggregator(intervalDuration, retain)
 
+AGGREGATE_LOOP:
 	for {
 		select {
 		case <-doneChan:
-			break
+			break AGGREGATE_LOOP
 		case cmd := <-cmdChan:
 			if cmd.Kind == cmdKindEvent {
 				agg.EmitEvent(cmd.Job, cmd.Event)

--- a/sinks/bugsnag/sink.go
+++ b/sinks/bugsnag/sink.go
@@ -71,10 +71,11 @@ func errorProcessingLoop(sink *Sink) {
 	cmdChan := sink.cmdChan
 	doneChan := sink.doneChan
 
+PROCESSING_LOOP:
 	for {
 		select {
 		case <-doneChan:
-			break
+			break PROCESSING_LOOP
 		case cmd := <-cmdChan:
 			if err := Notify(sink.Config, cmd.Job, cmd.Event, cmd.Err, cmd.Err.Stack); err != nil {
 				fmt.Fprintf(os.Stderr, "bugsnag.Notify: could not notify bugsnag. err=%v\n", err)


### PR DESCRIPTION
This pattern leads to a buzz loop (100% CPU) when `doneChan` is closed:

```
for {
    select {
    case <-doneChan:
        break
    // ...
    }
}
```

The `break` here applies to the inner `select`, not the outer `for` loop.

Attached commit follows the style of [healthd.go:109](https://github.com/gocraft/health/blob/a2525f4cf6696bfe1eca645bad968923775a68f9/healthd/healthd.go#L109), but `return` would work just as well.