### PR TITLE
BACKEND: Allow passing of request URL for Bugsnag Notifier API

### DIFF
--- a/sinks/bugsnag/api_test.go
+++ b/sinks/bugsnag/api_test.go
@@ -26,7 +26,7 @@ func TestNotify(t *testing.T) {
 
 	go http.ListenAndServe(":5051", n)
 
-	err := Notify(config, "users/get", "foo.bar", fmt.Errorf("imanerror"), stack.NewTrace(0))
+	err := Notify(config, "users/get", "foo.bar", fmt.Errorf("imanerror"), stack.NewTrace(0), make(map[string]string))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/sinks/bugsnag/sink.go
+++ b/sinks/bugsnag/sink.go
@@ -49,7 +49,7 @@ func (s *Sink) EmitEventErr(job string, event string, inputErr error, kvs map[st
 			s.cmdChan <- &cmdEventErr{Job: job, Event: event, Err: inputErr, Kvs: kvs}
 		}
 	case *health.MutedError:
-		// Do nothing!
+	// Do nothing!
 	default: // eg, case error:
 		// This shouldn't happen, all errors passed in here should be wrapped.
 	}
@@ -77,7 +77,7 @@ PROCESSING_LOOP:
 		case <-doneChan:
 			break PROCESSING_LOOP
 		case cmd := <-cmdChan:
-			if err := Notify(sink.Config, cmd.Job, cmd.Event, cmd.Err, cmd.Err.Stack); err != nil {
+			if err := Notify(sink.Config, cmd.Job, cmd.Event, cmd.Err, cmd.Err.Stack, cmd.Kvs); err != nil {
 				fmt.Fprintf(os.Stderr, "bugsnag.Notify: could not notify bugsnag. err=%v\n", err)
 			}
 		}


### PR DESCRIPTION
Squashed commit of the following:

commit 383ae391286d9f3e9be20a06f9fa242d1e1163ea
Author: Luke <lukeautry@gmail.com>
Date:   Mon Nov 23 15:58:58 2015 -0500

    re-add hostname event property; wasn't supposed to be removed

commit 7f54a57f7218a829abc0b03bc0583000488fb580
Author: Luke <lukeautry@gmail.com>
Date:   Mon Nov 23 15:43:38 2015 -0500

    use built-in map exists value instead of checking length

commit 18e532694c4a1446148ac71a524fc5a65a3e751c
Author: Luke <lukeautry@gmail.com>
Date:   Mon Nov 23 15:01:09 2015 -0500

    pass in key value store to bugsnag notifier; set request url metadata to allow viewing in bugsnag