### PR TITLE
Add a flag for terminal with dark background

### DIFF
--- a/cmd/healthtop/jobs.go
+++ b/cmd/healthtop/jobs.go
@@ -189,6 +189,8 @@ func printCellString(text string, table *goterm.Table, isBold, isGreen, isRed bo
 		color = goterm.GREEN
 	} else if isRed {
 		color = goterm.RED
+	} else if isDarkBackground {
+		color = goterm.WHITE
 	}
 
 	fmt.Fprintf(table, "%s\t", format(text, color, isBold))

--- a/cmd/healthtop/main.go
+++ b/cmd/healthtop/main.go
@@ -32,12 +32,14 @@ func (s *healthdStatus) FmtStatus() string {
 	}
 }
 
+var isDarkBackground bool
 var sourceHostPort string
 
 func main() {
 	var cmdRoot = &cobra.Command{
 		Use: "healthtop [command]",
 	}
+	cmdRoot.PersistentFlags().BoolVar(&isDarkBackground, "dark", false, "set the default font color to white for terminal with dark background")
 	cmdRoot.PersistentFlags().StringVar(&sourceHostPort, "source", "localhost:5032", "source is the host:port of the healthd to query. ex: localhost:5031")
 
 	var sort string


### PR DESCRIPTION
This pull request allows to set a dark flag, setting the default text color to white. It is useful for terminal with dark background, where the default black color is hard to read. Nothing impressive, but useful feature in my case :)

Thank you for your job on this awesome tool.
